### PR TITLE
Checking for $DOCKER_IMAGE_NAME_TO_TEST

### DIFF
--- a/tests/test_suite.bats
+++ b/tests/test_suite.bats
@@ -4,6 +4,10 @@ TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
 
 export TMP_GENERATION_DIR="${BATS_TEST_DIRNAME}/tmp"
 
+if [ -z "$DOCKER_IMAGE_NAME_TO_TEST" ]; then
+    export DOCKER_IMAGE_NAME_TO_TEST=asciidoctor/docker-asciidoctor
+fi
+
 clean_generated_files() {
   docker run -t --rm -v "${BATS_TEST_DIRNAME}:${BATS_TEST_DIRNAME}" alpine \
     rm -rf "${TMP_GENERATION_DIR}"


### PR DESCRIPTION
If $DOCKER_IMAGE_NAME_TO_TEST is not set the tests just throw errors. So you need to add the variable before. I added an check for the variable and if not set it sets to the default of `asciidoctor/docker-asciidoctor`. Will add a short note to README too.